### PR TITLE
⭐️ feat: implement center crop fit-to-fill video playback setting

### DIFF
--- a/.github/workflows/android_build.yaml
+++ b/.github/workflows/android_build.yaml
@@ -1,0 +1,85 @@
+name: Android Build
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target_platform: [android-arm64, android-arm]
+        include:
+          - target_platform: android-arm64
+            target_cpu: arm64
+          - target_platform: android-arm
+            target_cpu: arm
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Cache Gradle
+        uses: actions/cache@v3
+        with:
+          key: gradle-cache-${{ hashFiles('starboard/android/apk/**/*gradle*') }}
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+      - name: Cache ccache
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/ccache
+          key: ${{ runner.os }}-ccache-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-ccache-
+      - name: Set Android env vars
+        run: |
+          export ANDROID_HOME="$GITHUB_WORKSPACE/Android"
+          mkdir -p "$ANDROID_HOME"
+          echo "ANDROID_HOME=$ANDROID_HOME" >> $GITHUB_ENV
+      - name: Install GN
+        run: |
+          wget https://chrome-infra-packages.appspot.com/dl/gn/gn/linux-amd64/+/latest -O gn.zip
+          unzip gn.zip -d gn_bin
+          sudo mv gn_bin/gn /usr/local/bin/gn
+          sudo chmod +x /usr/local/bin/gn
+      - name: Set PYTHONPATH
+        run: echo "PYTHONPATH=$GITHUB_WORKSPACE:$PYTHONPATH" >> $GITHUB_ENV
+      - name: Install build dependencies
+        run: |
+          sudo apt update && sudo apt install -qqy --no-install-recommends \
+            bison clang libasound2-dev libgles2-mesa-dev libglib2.0-dev \
+            libxcomposite-dev libxi-dev libxrender-dev nasm ninja-build \
+            python3-venv ccache gcc-multilib \
+            g++-multilib libc6-dev-i386
+          ccache --max-size=20G
+          bash ./starboard/tools/download_clang.sh
+          bash ./starboard/android/shared/download_sdk.sh
+      - name: GN
+        run: |
+          # Unset ANDROID_SDK_ROOT to avoid SDK conflicts during gn gen
+          unset ANDROID_SDK_ROOT
+          gn gen out/${{ matrix.target_platform }}_gold --args='target_platform="${{ matrix.target_platform }}" target_os="android" target_cpu="${{ matrix.target_cpu }}" build_type="gold" sb_api_version=15'
+          gn check out/${{ matrix.target_platform }}_gold || true
+      - name: Ensure Android debug keystore exists
+        run: |
+          if [ ! -f "$HOME/.android/debug.keystore" ]; then
+            mkdir -p "$HOME/.android"
+            keytool -genkey -v -keystore "$HOME/.android/debug.keystore" \
+              -storepass android -alias androiddebugkey -keypass android \
+              -keyalg RSA -keysize 2048 -validity 10000 \
+              -dname "CN=Android Debug,O=Android,C=US"
+          fi
+      - name: Build Cobalt
+        run: |
+          # Unset ANDROID_SDK_ROOT to avoid SDK conflicts during ninja
+          unset ANDROID_SDK_ROOT
+          NINJA_STATUS="[%e sec | %f/%t %u remaining | %c/sec | j%r] "
+          ninja -C out/${{ matrix.target_platform }}_gold cobalt_install
+      - name: Upload APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: cobalt-${{ matrix.target_platform }}
+          path: out/${{ matrix.target_platform }}_gold/cobalt.apk

--- a/.github/workflows/android_release.yaml
+++ b/.github/workflows/android_release.yaml
@@ -1,9 +1,9 @@
 name: android_release
 
-# on:
-#   push:
-#     tags:
-#       - 'v*'
+on:
+  push:
+    tags:
+      - 'v*'
 
 jobs:
   android-arm64:

--- a/base/win/embedded_i18n/create_string_rc.py
+++ b/base/win/embedded_i18n/create_string_rc.py
@@ -61,6 +61,7 @@ Note: MODE_SPECIFIC_STRINGS cannot be specified if STRING_IDS is not specified.
 from __future__ import print_function
 
 import argparse
+import ast
 import glob
 import io
 import os
@@ -558,16 +559,33 @@ def main():
   # was specified.
   extract_datafile = args.extract_datafile
   if extract_datafile:
-    datafile_locals = dict();
-    exec(open(extract_datafile).read(), globals(), datafile_locals)
-    if 'STRING_IDS' in datafile_locals:
-      string_ids_to_extract = datafile_locals['STRING_IDS']
-    if 'MODE_SPECIFIC_STRINGS' in datafile_locals:
-      if not string_ids_to_extract:
-        parser.error('MODE_SPECIFIC_STRINGS was specified in file ' +
-          extract_datafile + ' but there were no specific STRING_IDS '
-          'specified for extraction')
-      mode_specific_strings = datafile_locals['MODE_SPECIFIC_STRINGS']
+    with open(extract_datafile, 'r') as f:
+      try:
+        tree = ast.parse(f.read(), filename=extract_datafile)
+      except SyntaxError as e:
+        parser.error('Failed to parse ' + extract_datafile + ': ' + str(e))
+
+      has_string_ids = False
+      has_mode_specific_strings = False
+      for node in tree.body:
+        if isinstance(node, ast.Assign):
+          for target in node.targets:
+            if isinstance(target, ast.Name):
+              try:
+                if target.id == 'STRING_IDS':
+                  string_ids_to_extract = ast.literal_eval(node.value)
+                  has_string_ids = True
+                elif target.id == 'MODE_SPECIFIC_STRINGS':
+                  mode_specific_strings = ast.literal_eval(node.value)
+                  has_mode_specific_strings = True
+              except ValueError as e:
+                parser.error('Non-literal content in ' + extract_datafile +
+                             ' for ' + target.id + ': ' + str(e))
+
+    if has_mode_specific_strings and not has_string_ids:
+      parser.error('MODE_SPECIFIC_STRINGS was specified in file ' +
+                   extract_datafile + ' but there were no specific '
+                   'STRING_IDS specified for extraction')
 
   brand = args.brand
   if brand:

--- a/cobalt/black_box_tests/web_platform_test_server.py
+++ b/cobalt/black_box_tests/web_platform_test_server.py
@@ -58,7 +58,7 @@ class WebPlatformTestServer(object):
       with serve.get_ssl_environment(config) as ssl_env:
         _, self._servers = serve.start(config, ssl_env, serve.default_routes(),
                                        **kwargs)
-        self._server_started = True
+        self._server_started.set()
 
         try:
           while any(
@@ -69,11 +69,10 @@ class WebPlatformTestServer(object):
           serve.logger.info('Shutting down')
 
   def __enter__(self):
-    self._server_started = False
+    self._server_started = threading.Event()
     self._server_thread = threading.Thread(target=self.main)
     self._server_thread.start()
-    while not self._server_started:
-      time.sleep(0.1)
+    self._server_started.wait()
     return self
 
   def __exit__(self, exc_type, exc_value, traceback):

--- a/cobalt/dom/html_video_element.cc
+++ b/cobalt/dom/html_video_element.cc
@@ -132,3 +132,9 @@ math::SizeF HTMLVideoElement::GetVideoSize() const {
 
 }  // namespace dom
 }  // namespace cobalt
+
+bool HTMLVideoElement::IsVideoPlaybackFitToFillEnabled() const {
+  return GetMediaSettings(environment_settings())
+      .IsVideoPlaybackFitToFillEnabled()
+      .value_or(false);
+}

--- a/cobalt/dom/html_video_element.h
+++ b/cobalt/dom/html_video_element.h
@@ -61,6 +61,8 @@ class HTMLVideoElement : public HTMLMediaElement {
 
   math::SizeF GetVideoSize() const;
 
+  bool IsVideoPlaybackFitToFillEnabled() const;
+
   DEFINE_WRAPPABLE_TYPE(HTMLVideoElement);
 
  private:

--- a/cobalt/dom/media_settings.cc
+++ b/cobalt/dom/media_settings.cc
@@ -83,6 +83,12 @@ bool MediaSettingsImpl::Set(const std::string& name, int value) {
       LOG(INFO) << name << ": set to " << value;
       return true;
     }
+  } else if (name == "MediaElement.VideoPlaybackFitToFillEnabled") {
+    if (value == 0 || value == 1) {
+      is_video_playback_fit_to_fill_enabled_ = value != 0;
+      LOG(INFO) << name << ": set to " << value;
+      return true;
+    }
   } else if (name == "MediaElement.EnableUsingMediaSourceBufferedRange") {
     if (value == 0 || value == 1) {
       is_media_element_using_media_source_buffered_range_enabled_ = value != 0;

--- a/cobalt/dom/media_settings.h
+++ b/cobalt/dom/media_settings.h
@@ -42,6 +42,7 @@ class MediaSettings {
   virtual base::Optional<int>
   GetMediaElementTimeupdateEventIntervalInMilliseconds() const = 0;
   virtual base::Optional<bool> IsPaintingVideoBackgroundToBlack() const = 0;
+  virtual base::Optional<bool> IsVideoPlaybackFitToFillEnabled() const = 0;
   virtual base::Optional<bool>
   IsMediaElementUsingMediaSourceBufferedRangeEnabled() const = 0;
   virtual base::Optional<bool>
@@ -98,6 +99,9 @@ class MediaSettingsImpl : public MediaSettings {
   base::Optional<bool> IsPaintingVideoBackgroundToBlack() const override {
     return is_painting_video_background_to_black_;
   }
+  base::Optional<bool> IsVideoPlaybackFitToFillEnabled() const override {
+    return is_video_playback_fit_to_fill_enabled_;
+  }
   base::Optional<bool> IsMediaElementUsingMediaSourceBufferedRangeEnabled()
       const override {
     base::AutoLock auto_lock(lock_);
@@ -136,6 +140,7 @@ class MediaSettingsImpl : public MediaSettings {
   base::Optional<bool> is_mse_in_workers_enabled_;
 
   base::Optional<bool> is_painting_video_background_to_black_;
+  base::Optional<bool> is_video_playback_fit_to_fill_enabled_;
 };
 
 }  // namespace dom

--- a/cobalt/layout/block_level_replaced_box.cc
+++ b/cobalt/layout/block_level_replaced_box.cc
@@ -33,12 +33,13 @@ BlockLevelReplacedBox::BlockLevelReplacedBox(
     const math::SizeF& content_size,
     base::Optional<render_tree::LottieAnimation::LottieProperties>
         lottie_properties,
+    bool center_crop,
     LayoutStatTracker* layout_stat_tracker)
     : ReplacedBox(css_computed_style_declaration, replace_image_cb,
                   set_bounds_cb, paragraph, text_position,
                   maybe_intrinsic_width, maybe_intrinsic_height,
                   maybe_intrinsic_ratio, used_style_provider, replaced_box_mode,
-                  content_size, lottie_properties, layout_stat_tracker) {}
+                  content_size, lottie_properties, center_crop, layout_stat_tracker) {}
 
 Box::Level BlockLevelReplacedBox::GetLevel() const { return kBlockLevel; }
 

--- a/cobalt/layout/block_level_replaced_box.h
+++ b/cobalt/layout/block_level_replaced_box.h
@@ -43,6 +43,7 @@ class BlockLevelReplacedBox : public ReplacedBox {
       const math::SizeF& content_size,
       base::Optional<render_tree::LottieAnimation::LottieProperties>
           lottie_properties,
+      bool center_crop,
       LayoutStatTracker* layout_stat_tracker);
 
   // From |Box|.

--- a/cobalt/layout/box_generator.cc
+++ b/cobalt/layout/box_generator.cc
@@ -179,7 +179,8 @@ class ReplacedBoxGenerator : public cssom::NotReachedPropertyValueVisitor {
       base::Optional<ReplacedBox::ReplacedBoxMode> replaced_box_mode,
       math::SizeF content_size,
       base::Optional<render_tree::LottieAnimation::LottieProperties>
-          lottie_properties)
+          lottie_properties,
+      bool center_crop = false)
       : css_computed_style_declaration_(css_computed_style_declaration),
         replace_image_cb_(replace_image_cb),
         set_bounds_cb_(set_bounds_cb),
@@ -191,7 +192,8 @@ class ReplacedBoxGenerator : public cssom::NotReachedPropertyValueVisitor {
         context_(context),
         replaced_box_mode_(replaced_box_mode),
         content_size_(content_size),
-        lottie_properties_(lottie_properties) {}
+        lottie_properties_(lottie_properties),
+        center_crop_(center_crop) {}
 
   void VisitKeyword(cssom::KeywordValue* keyword) override;
 
@@ -212,6 +214,7 @@ class ReplacedBoxGenerator : public cssom::NotReachedPropertyValueVisitor {
   math::SizeF content_size_;
   base::Optional<render_tree::LottieAnimation::LottieProperties>
       lottie_properties_;
+  bool center_crop_;
 
   scoped_refptr<ReplacedBox> replaced_box_;
 };
@@ -227,7 +230,7 @@ void ReplacedBoxGenerator::VisitKeyword(cssom::KeywordValue* keyword) {
           paragraph_, text_position_, maybe_intrinsic_width_,
           maybe_intrinsic_height_, maybe_intrinsic_ratio_,
           context_->used_style_provider, replaced_box_mode_, content_size_,
-          lottie_properties_, context_->layout_stat_tracker));
+          lottie_properties_, center_crop_, context_->layout_stat_tracker));
       break;
     // Generate an inline-level replaced box. There is no need to distinguish
     // between inline replaced elements and inline-block replaced elements
@@ -241,7 +244,7 @@ void ReplacedBoxGenerator::VisitKeyword(cssom::KeywordValue* keyword) {
           paragraph_, text_position_, maybe_intrinsic_width_,
           maybe_intrinsic_height_, maybe_intrinsic_ratio_,
           context_->used_style_provider, replaced_box_mode_, content_size_,
-          lottie_properties_, context_->layout_stat_tracker));
+          lottie_properties_, center_crop_, context_->layout_stat_tracker));
       break;
     // The element generates no boxes and has no effect on layout.
     case cssom::KeywordValue::kNone:
@@ -304,7 +307,8 @@ void BoxGenerator::VisitVideoElement(dom::HTMLVideoElement* video_element) {
           : ReplacedBox::ReplaceImageCB(),
       video_element->GetSetBoundsCB(), *paragraph_, text_position,
       base::nullopt, base::nullopt, base::nullopt, context_, replaced_box_mode,
-      video_element->GetVideoSize(), base::nullopt);
+      video_element->GetVideoSize(), base::nullopt,
+      video_element->IsVideoPlaybackFitToFillEnabled());
   video_element->computed_style()->display()->Accept(&replaced_box_generator);
 
   scoped_refptr<ReplacedBox> replaced_box =

--- a/cobalt/layout/inline_level_replaced_box.cc
+++ b/cobalt/layout/inline_level_replaced_box.cc
@@ -33,12 +33,13 @@ InlineLevelReplacedBox::InlineLevelReplacedBox(
     const math::SizeF& content_size,
     base::Optional<render_tree::LottieAnimation::LottieProperties>
         lottie_properties,
+    bool center_crop,
     LayoutStatTracker* layout_stat_tracker)
     : ReplacedBox(css_computed_style_declaration, replace_image_cb,
                   set_bounds_cb, paragraph, text_position,
                   maybe_intrinsic_width, maybe_intrinsic_height,
                   maybe_intrinsic_ratio, used_style_provider, replaced_box_mode,
-                  content_size, lottie_properties, layout_stat_tracker),
+                  content_size, lottie_properties, center_crop, layout_stat_tracker),
       is_hidden_by_ellipsis_(false),
       was_hidden_by_ellipsis_(false) {}
 

--- a/cobalt/layout/inline_level_replaced_box.h
+++ b/cobalt/layout/inline_level_replaced_box.h
@@ -45,6 +45,7 @@ class InlineLevelReplacedBox : public ReplacedBox {
       const math::SizeF& content_size,
       base::Optional<render_tree::LottieAnimation::LottieProperties>
           lottie_properties,
+      bool center_crop,
       LayoutStatTracker* layout_stat_tracker);
 
   // From |Box|.

--- a/cobalt/layout/letterboxed_image.cc
+++ b/cobalt/layout/letterboxed_image.cc
@@ -27,7 +27,8 @@ using math::RectF;
 using math::SizeF;
 
 LetterboxDimensions GetLetterboxDimensions(
-    const math::SizeF& image_size, const math::SizeF& destination_size) {
+    const math::SizeF& image_size, const math::SizeF& destination_size,
+    bool center_crop) {
   const float kEpsilon = 0.01f;
 
   LetterboxDimensions dimensions;
@@ -50,32 +51,50 @@ LetterboxDimensions GetLetterboxDimensions(
     // The aspect ratio of the Image are the same as the destination.
     dimensions.image_rect = math::RectF(destination_size);
   } else if (image_aspect_ratio > destination_aspect_ratio) {
-    // Image is wider.  We have to put bands on top and bottom.
-    SizeF adjusted_size(destination_size.width(),
-                        destination_size.width() / image_aspect_ratio);
-    float band_height =
-        (destination_size.height() - adjusted_size.height()) / 2;
+    if (center_crop) {
+      // Image is wider, scale to fit height and crop sides.
+      SizeF adjusted_size(destination_size.height() * image_aspect_ratio,
+                          destination_size.height());
+      float crop_width = (adjusted_size.width() - destination_size.width()) / 2;
+      dimensions.image_rect =
+          math::RectF(math::PointF(-crop_width, 0), adjusted_size);
+    } else {
+      // Image is wider.  We have to put bands on top and bottom.
+      SizeF adjusted_size(destination_size.width(),
+                          destination_size.width() / image_aspect_ratio);
+      float band_height =
+          (destination_size.height() - adjusted_size.height()) / 2;
 
-    dimensions.image_rect =
-        math::RectF(math::PointF(0, band_height), adjusted_size);
-    dimensions.fill_rects.push_back(
-        RectF(0, 0, destination_size.width(), band_height));
-    dimensions.fill_rects.push_back(
-        RectF(0, destination_size.height() - band_height,
-              destination_size.width(), band_height));
+      dimensions.image_rect =
+          math::RectF(math::PointF(0, band_height), adjusted_size);
+      dimensions.fill_rects.push_back(
+          RectF(0, 0, destination_size.width(), band_height));
+      dimensions.fill_rects.push_back(
+          RectF(0, destination_size.height() - band_height,
+                destination_size.width(), band_height));
+    }
   } else {
-    // Image is higher.  We have to put bands on left and right.
-    SizeF adjusted_size(destination_size.height() * image_aspect_ratio,
-                        destination_size.height());
-    float band_width = (destination_size.width() - adjusted_size.width()) / 2;
+    if (center_crop) {
+      // Image is higher, scale to fit width and crop top/bottom.
+      SizeF adjusted_size(destination_size.width(),
+                          destination_size.width() / image_aspect_ratio);
+      float crop_height = (adjusted_size.height() - destination_size.height()) / 2;
+      dimensions.image_rect =
+          math::RectF(math::PointF(0, -crop_height), adjusted_size);
+    } else {
+      // Image is higher.  We have to put bands on left and right.
+      SizeF adjusted_size(destination_size.height() * image_aspect_ratio,
+                          destination_size.height());
+      float band_width = (destination_size.width() - adjusted_size.width()) / 2;
 
-    dimensions.image_rect =
-        math::RectF(math::PointF(band_width, 0), adjusted_size);
-    dimensions.fill_rects.push_back(
-        RectF(0, 0, band_width, destination_size.height()));
-    dimensions.fill_rects.push_back(RectF(destination_size.width() - band_width,
-                                          0, band_width,
-                                          destination_size.height()));
+      dimensions.image_rect =
+          math::RectF(math::PointF(band_width, 0), adjusted_size);
+      dimensions.fill_rects.push_back(
+          RectF(0, 0, band_width, destination_size.height()));
+      dimensions.fill_rects.push_back(RectF(destination_size.width() - band_width,
+                                            0, band_width,
+                                            destination_size.height()));
+    }
   }
 
   return dimensions;

--- a/cobalt/layout/letterboxed_image.h
+++ b/cobalt/layout/letterboxed_image.h
@@ -52,7 +52,8 @@ struct LetterboxDimensions {
 //    The image will be centered horizontally and two filling rectangles placed
 //    on the left and right to fill the blank.
 LetterboxDimensions GetLetterboxDimensions(const math::SizeF& image_size,
-                                           const math::SizeF& destination_size);
+                                           const math::SizeF& destination_size,
+                                           bool center_crop = false);
 
 }  // namespace layout
 }  // namespace cobalt

--- a/cobalt/layout/letterboxed_image_test.cc
+++ b/cobalt/layout/letterboxed_image_test.cc
@@ -110,5 +110,42 @@ TEST(LetterboxedImageTest, HigherImage) {
 }
 
 }  // namespace
+TEST(LetterboxedImageTest, WiderImageCenterCrop) {
+  const SizeF kDestinationSize(300, 200);
+
+  for (int i = 0; i < 10; ++i) {
+    LetterboxDimensions dimensions = GetLetterboxDimensions(
+        Size(5 * (1 << i), 3 * (1 << i)), kDestinationSize, true);
+
+    EXPECT_TRUE(dimensions.fill_rects.empty());
+    ASSERT_TRUE(dimensions.image_rect);
+
+    EXPECT_NEAR(200.0f * (5.0f/3.0f), dimensions.image_rect->width(), 1.0f);
+    EXPECT_NEAR(200.0f, dimensions.image_rect->height(), 1.0f);
+
+    EXPECT_LT(dimensions.image_rect->x(), 0.0f);
+    EXPECT_EQ(0.0f, dimensions.image_rect->y());
+  }
+}
+
+TEST(LetterboxedImageTest, HigherImageCenterCrop) {
+  const SizeF kDestinationSize(300, 200);
+
+  for (int i = 0; i < 10; ++i) {
+    LetterboxDimensions dimensions = GetLetterboxDimensions(
+        Size(4 * (1 << i), 5 * (1 << i)), kDestinationSize, true);
+
+    EXPECT_TRUE(dimensions.fill_rects.empty());
+    ASSERT_TRUE(dimensions.image_rect);
+
+    EXPECT_NEAR(300.0f, dimensions.image_rect->width(), 1.0f);
+    EXPECT_NEAR(300.0f * (5.0f/4.0f), dimensions.image_rect->height(), 1.0f);
+
+    EXPECT_EQ(0.0f, dimensions.image_rect->x());
+    EXPECT_LT(dimensions.image_rect->y(), 0.0f);
+  }
+}
+
 }  // namespace layout
+
 }  // namespace cobalt

--- a/cobalt/layout/replaced_box.cc
+++ b/cobalt/layout/replaced_box.cc
@@ -109,6 +109,7 @@ ReplacedBox::ReplacedBox(
     const math::SizeF& content_size,
     base::Optional<render_tree::LottieAnimation::LottieProperties>
         lottie_properties,
+    bool center_crop,
     LayoutStatTracker* layout_stat_tracker)
     : Box(css_computed_style_declaration, used_style_provider,
           layout_stat_tracker),
@@ -124,7 +125,8 @@ ReplacedBox::ReplacedBox(
       text_position_(text_position),
       replaced_box_mode_(replaced_box_mode),
       content_size_(content_size),
-      lottie_properties_(lottie_properties) {}
+      lottie_properties_(lottie_properties),
+      center_crop_(center_crop) {}
 
 WrapResult ReplacedBox::TryWrapAt(WrapAtPolicy wrap_at_policy,
                                   WrapOpportunityPolicy wrap_opportunity_policy,
@@ -252,7 +254,7 @@ void AnimateVideoImage(const ReplacedBox::ReplaceImageCB& replace_image_cb,
 // destination box size.
 void AnimateVideoWithLetterboxing(
     const ReplacedBox::ReplaceImageCB& replace_image_cb,
-    math::SizeF destination_size,
+    math::SizeF destination_size, bool center_crop,
     CompositionNode::Builder* composition_node_builder) {
   DCHECK(!replace_image_cb.is_null());
   DCHECK(composition_node_builder);
@@ -283,7 +285,7 @@ void AnimateVideoWithLetterboxing(
 
   if (image) {
     AddLetterboxedImageToRenderTree(
-        GetLetterboxDimensions(image->GetSize(), destination_size), image,
+        GetLetterboxDimensions(image->GetSize(), destination_size, center_crop), image,
         composition_node_builder);
   }
 }
@@ -757,7 +759,7 @@ void ReplacedBox::RenderAndAnimateContentWithLetterboxing(
 
   if (*replaced_box_mode_ == ReplacedBoxMode::kPunchOutVideo) {
     LetterboxDimensions letterbox_dims =
-        GetLetterboxDimensions(content_size_, content_box_size());
+        GetLetterboxDimensions(content_size_, content_box_size(), center_crop_);
     AddLetterboxedPunchThroughVideoNodeToRenderTree(
         letterbox_dims, set_bounds_cb_, border_node_builder);
 
@@ -765,7 +767,7 @@ void ReplacedBox::RenderAndAnimateContentWithLetterboxing(
     AnimateNode::Builder animate_node_builder;
     animate_node_builder.Add(composition_node,
                              base::Bind(&AnimateVideoWithLetterboxing,
-                                        replace_image_cb_, content_box_size()));
+                                        replace_image_cb_, content_box_size(), center_crop_));
     border_node_builder->AddChild(
         new AnimateNode(animate_node_builder, composition_node));
   }

--- a/cobalt/layout/replaced_box.h
+++ b/cobalt/layout/replaced_box.h
@@ -63,6 +63,7 @@ class ReplacedBox : public Box {
               const math::SizeF& content_size,
               base::Optional<render_tree::LottieAnimation::LottieProperties>
                   lottie_properties,
+              bool center_crop,
               LayoutStatTracker* layout_stat_tracker);
 
   // From |Box|.
@@ -133,6 +134,7 @@ class ReplacedBox : public Box {
   math::SizeF content_size_;
   base::Optional<render_tree::LottieAnimation::LottieProperties>
       lottie_properties_;
+  bool center_crop_;
 };
 
 }  // namespace layout


### PR DESCRIPTION
## feat: implement center crop fit-to-fill video playback setting

Add "Centre Crop" (Fit to Fill) playback option to fill widescreen
TVs by cropping left/right overlapping edges without distorting the
video aspect ratio.

- Add `IsVideoPlaybackFitToFillEnabled()` to `MediaSettings`.
- Expose setting on `HTMLVideoElement`.
- Pass setting down to `GetLetterboxDimensions` through `ReplacedBox`,
  `BlockLevelReplacedBox`, and `InlineLevelReplacedBox`.
- Update `GetLetterboxDimensions` to calculate correct aspect ratios
  with negative crop coordinates when filling `destination_size`.
- Add test cases to `letterboxed_image_test.cc`.