### PR TITLE
fix: remove hardcoded Android dependency from h5vcc_tizen_tube BUILD.gn for Linux builds

### DIFF
--- a/third_party/blink/renderer/modules/cobalt/h5vcc_tizen_tube/BUILD.gn
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_tizen_tube/BUILD.gn
@@ -20,5 +20,5 @@ blink_modules_sources("h5vcc_tizen_tube") {
     "h_5_vcc_tizen_tube.h",
   ]
 
-  deps = [ "//cobalt/browser/h5vcc_tizentube/public/mojom:mojom_blink", "//starboard/android/shared:starboard_platform" ]
+  deps = [ "//cobalt/browser/h5vcc_tizentube/public/mojom:mojom_blink",  ]
 }


### PR DESCRIPTION
### Problem
When compiling Cobalt for Linux/Evergreen targets (like `evergreen-arm64`), the build fails during the GN generation phase. This is because the custom module `h5vcc_tizen_tube` hardcodes a dependency on `//starboard/android/shared:starboard_platform` in its `BUILD.gn`, which triggers the following assertion failure:
`assert(is_android || is_chromeos || is_robolectric)`

### Solution
Removed the hardcoded Android starboard platform dependency from `third_party/blink/renderer/modules/cobalt/h5vcc_tizen_tube/BUILD.gn` to allow successful compilation on non-Android (Linux) targets.