### PR TITLE
Connection error menu translations

### DIFF
--- a/cobalt/shell/android/java/res/values-de/strings.xml
+++ b/cobalt/shell/android/java/res/values-de/strings.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  Copyright 2025 The Cobalt Authors. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<resources>
+<string name="url_hint">URL hier eingeben</string>
+    <string name="browser_process_initialization_failed">Initialisierung fehlgeschlagen.</string>
+    <!-- Error message when there's a problem connecting to the network. -->
+    <string name="starboard_platform_connection_error">Verbindung derzeit nicht möglich</string>
+    <!-- Button label on network connection error to retry the request. -->
+    <string name="starboard_platform_retry">Erneut versuchen</string>
+    <!-- Button label on network connection error to open system network settings. -->
+    <string name="starboard_platform_network_settings">Netzwerkeinstellungen öffnen</string>
+    <!-- Button label to dismiss an error message dialog. -->
+    <string name="starboard_platform_dismiss">Schließen</string>
+    <!-- Toast message when we can't get the device account to sign in. -->
+    <string name="starboard_account_picker_error">Konto nicht verfügbar.</string>
+    <!-- Toast message when we the account can't be authorized. -->
+    <string name="starboard_account_auth_error">Kontoautorisierung fehlgeschlagen.</string>
+    <!-- Toast message indicating that the selected account is no longer available to sign-in. -->
+    <string name="starboard_missing_account">Konto nicht verfügbar:\n%1$s</string>
+    <!-- Toast message shown when the user has denied permission to get device accounts. -->
+    <string name="starboard_accounts_permission">Für die Anmeldung muss die Berechtigung für Kontakte in den Systemeinstellungen erteilt werden.</string>	
+</resources>

--- a/cobalt/shell/android/java/res/values-es/strings.xml
+++ b/cobalt/shell/android/java/res/values-es/strings.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  Copyright 2025 The Cobalt Authors. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<resources>
+<string name="url_hint">Escribe la URL aquí</string>
+    <string name="browser_process_initialization_failed">Error de inicialización.</string>
+    <!-- Error message when there's a problem connecting to the network. -->
+    <string name="starboard_platform_connection_error">No se puede conectar en este momento</string>
+    <!-- Button label on network connection error to retry the request. -->
+    <string name="starboard_platform_retry">Reintentar</string>
+    <!-- Button label on network connection error to open system network settings. -->
+    <string name="starboard_platform_network_settings">Abrir configuración de red</string>
+    <!-- Button label to dismiss an error message dialog. -->
+    <string name="starboard_platform_dismiss">Cerrar</string>
+    <!-- Toast message when we can't get the device account to sign in. -->
+    <string name="starboard_account_picker_error">Cuenta no disponible.</string>
+    <!-- Toast message when we the account can't be authorized. -->
+    <string name="starboard_account_auth_error">La autorización de la cuenta falló.</string>
+    <!-- Toast message indicating that the selected account is no longer available to sign-in. -->
+    <string name="starboard_missing_account">Cuenta no disponible:\n%1$s</string>
+    <!-- Toast message shown when the user has denied permission to get device accounts. -->
+    <string name="starboard_accounts_permission">Iniciar sesión requiere que se conceda el permiso de Contactos en la configuración del sistema.</string>
+</resources>

--- a/cobalt/shell/android/java/res/values-fr/strings.xml
+++ b/cobalt/shell/android/java/res/values-fr/strings.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  Copyright 2025 The Cobalt Authors. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<resources>
+    <string name="url_hint">Saisissez l\'URL ici</string>
+    <string name="browser_process_initialization_failed">Échec de l\'initialisation.</string>
+    <!-- Error message when there's a problem connecting to the network. -->
+    <string name="starboard_platform_connection_error">Connexion impossible pour le moment</string>
+    <!-- Button label on network connection error to retry the request. -->
+    <string name="starboard_platform_retry">Réessayer</string>
+    <!-- Button label on network connection error to open system network settings. -->
+    <string name="starboard_platform_network_settings">Ouvrir les paramètres réseau</string>
+    <!-- Button label to dismiss an error message dialog. -->
+    <string name="starboard_platform_dismiss">Ignorer</string>
+    <!-- Toast message when we can't get the device account to sign in. -->
+    <string name="starboard_account_picker_error">Compte non disponible.</string>
+    <!-- Toast message when we the account can't be authorized. -->
+    <string name="starboard_account_auth_error">Échec de l\'autorisation du compte.</string>
+    <!-- Toast message indicating that the selected account is no longer available to sign-in. -->
+    <string name="starboard_missing_account">Compte non disponible:\n%1$s</string>
+    <!-- Toast message shown when the user has denied permission to get device accounts. -->
+    <string name="starboard_accounts_permission">La connexion nécessite l\'autorisation d\'accès aux contacts dans les paramètres système.</string>
+</resources>

--- a/cobalt/shell/android/java/res/values-it/strings.xml
+++ b/cobalt/shell/android/java/res/values-it/strings.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  Copyright 2025 The Cobalt Authors. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<resources>
+<string name="url_hint">Inserisci l\'URL qui</string>
+    <string name="browser_process_initialization_failed">Inizializzazione non riuscita.</string>
+    <!-- Error message when there's a problem connecting to the network. -->
+    <string name="starboard_platform_connection_error">Impossibile connettersi in questo momento</string>
+    <!-- Button label on network connection error to retry the request. -->
+    <string name="starboard_platform_retry">Riprova</string>
+    <!-- Button label on network connection error to open system network settings. -->
+    <string name="starboard_platform_network_settings">Apri le impostazioni di rete</string>
+    <!-- Button label to dismiss an error message dialog. -->
+    <string name="starboard_platform_dismiss">Ignora</string>
+    <!-- Toast message when we can't get the device account to sign in. -->
+    <string name="starboard_account_picker_error">Account non disponibile.</string>
+    <!-- Toast message when we the account can't be authorized. -->
+    <string name="starboard_account_auth_error">Autorizzazione dell\'account non riuscita.</string>
+    <!-- Toast message indicating that the selected account is no longer available to sign-in. -->
+    <string name="starboard_missing_account">Account non disponibile:\n%1$s</string>
+    <!-- Toast message shown when the user has denied permission to get device accounts. -->
+    <string name="starboard_accounts_permission">L\'accesso richiede di concedere l\'autorizzazione per i Contatti nelle impostazioni di sistema.</string>	
+</resources>

--- a/cobalt/shell/android/java/res/values-pl-rSP/strings.xml
+++ b/cobalt/shell/android/java/res/values-pl-rSP/strings.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  Copyright 2025 The Cobalt Authors. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<resources>
+    <string name="url_hint">Wprowadź tu adres URL</string>
+    <string name="browser_process_initialization_failed">Inicjalizacyjŏ niy podarziła sie.</string>
+    <!-- Error message when there's a problem connecting to the network. -->
+    <string name="starboard_platform_connection_error">Kable ci keryś przeryzōł?</string>
+    <!-- Button label on network connection error to retry the request. -->
+    <string name="starboard_platform_retry">Sprōbuj niyskorzij</string>
+    <!-- Button label on network connection error to open system network settings. -->
+    <string name="starboard_platform_network_settings">Ôdewrzij nasztalowania neca</string>
+    <!-- Button label to dismiss an error message dialog. -->
+    <string name="starboard_platform_dismiss">Zawrzij</string>
+    <!-- Toast message when we can't get the device account to sign in. -->
+    <string name="starboard_account_picker_error">Kōnto je niydostympne.</string>
+    <!-- Toast message when we the account can't be authorized. -->
+    <string name="starboard_account_auth_error">Autoryzacyjŏ kōnta niy podarziła sie</string>
+    <!-- Toast message indicating that the selected account is no longer available to sign-in. -->
+    <string name="starboard_missing_account">Kōnto je niydostympne:\n%1$s</string>
+    <!-- Toast message shown when the user has denied permission to get device accounts. -->
+    <string name="starboard_accounts_permission">Logowaniy wymagŏ przizwolyniŏ na dostymp do Kōntaktōw w nasztalowaniach systymu.</string>
+</resources>

--- a/cobalt/shell/android/java/res/values-pl/strings.xml
+++ b/cobalt/shell/android/java/res/values-pl/strings.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  Copyright 2025 The Cobalt Authors. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<resources>
+    <string name="url_hint">Wprowadź tu adres URL</string>
+    <string name="browser_process_initialization_failed">Initialization failed.</string>
+    <!-- Error message when there's a problem connecting to the network. -->
+    <string name="starboard_platform_connection_error">Coś poszło nie tak z połączeniem</string>
+    <!-- Button label on network connection error to retry the request. -->
+    <string name="starboard_platform_retry">Spróbuj ponownie</string>
+    <!-- Button label on network connection error to open system network settings. -->
+    <string name="starboard_platform_network_settings">Otwórz ustawienia sieci</string>
+    <!-- Button label to dismiss an error message dialog. -->
+    <string name="starboard_platform_dismiss">Zamknij</string>
+    <!-- Toast message when we can't get the device account to sign in. -->
+    <string name="starboard_account_picker_error">Konto jest niedostępne.</string>
+    <!-- Toast message when we the account can't be authorized. -->
+    <string name="starboard_account_auth_error">Autoryzacja konta nie powiodła się</string>
+    <!-- Toast message indicating that the selected account is no longer available to sign-in. -->
+    <string name="starboard_missing_account">Konto jest niedostępne:\n%1$s</string>
+    <!-- Toast message shown when the user has denied permission to get device accounts. -->
+    <string name="starboard_accounts_permission">Logowanie wymaga przyznania uprawnień do Kontaktów w ustawieniach systemu.</string>
+</resources>

--- a/cobalt/shell/android/java/res/values-szl/strings.xml
+++ b/cobalt/shell/android/java/res/values-szl/strings.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  Copyright 2025 The Cobalt Authors. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<resources>
+    <string name="url_hint">Wprowadź tu adres URL</string>
+    <string name="browser_process_initialization_failed">Inicjalizacyjŏ niy podarziła sie.</string>
+    <!-- Error message when there's a problem connecting to the network. -->
+    <string name="starboard_platform_connection_error">Kable ci keryś przeryzōł?</string>
+    <!-- Button label on network connection error to retry the request. -->
+    <string name="starboard_platform_retry">Sprōbuj niyskorzij</string>
+    <!-- Button label on network connection error to open system network settings. -->
+    <string name="starboard_platform_network_settings">Ôdewrzij nasztalowania neca</string>
+    <!-- Button label to dismiss an error message dialog. -->
+    <string name="starboard_platform_dismiss">Zawrzij</string>
+    <!-- Toast message when we can't get the device account to sign in. -->
+    <string name="starboard_account_picker_error">Kōnto je niydostympne.</string>
+    <!-- Toast message when we the account can't be authorized. -->
+    <string name="starboard_account_auth_error">Autoryzacyjŏ kōnta niy podarziła sie</string>
+    <!-- Toast message indicating that the selected account is no longer available to sign-in. -->
+    <string name="starboard_missing_account">Kōnto je niydostympne:\n%1$s</string>
+    <!-- Toast message shown when the user has denied permission to get device accounts. -->
+    <string name="starboard_accounts_permission">Logowaniy wymagŏ przizwolyniŏ na dostymp do Kōntaktōw w nasztalowaniach systymu.</string>
+</resources>


### PR DESCRIPTION
### Adds the following translations for the menu that appears when a connection issue has been encountered on launch:
- German
- Italian
- Polish
- Silesian
- Spanish
### Additions 
- French by Magictor24

----
### Menu that I'm reffering to
<img width="1280" height="720" alt="Screenshot_20260811-132353" src="https://github.com/user-attachments/assets/f2bc1fce-9e90-4e9c-8a7b-f258e9d81f67" />
